### PR TITLE
fix: avoid emitting warnings when ruby is run with `-w`

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--warnings

--- a/lib/simplecov_json_formatter/source_file_formatter.rb
+++ b/lib/simplecov_json_formatter/source_file_formatter.rb
@@ -4,6 +4,7 @@ module SimpleCovJSONFormatter
   class SourceFileFormatter
     def initialize(source_file)
       @source_file = source_file
+      @line_coverage = nil
     end
 
     def format
@@ -17,7 +18,7 @@ module SimpleCovJSONFormatter
     private
 
     def line_coverage
-      @line_coverage || {
+      @line_coverage ||= {
         lines: lines
       }
     end


### PR DESCRIPTION
I've also turned on warnings for this gem's tests, to make it more obvious when this is happening in the future.

Without this fix, users will see repeated messages like this:

> source_file_formatter.rb:20: warning: instance variable @line_coverage not initialized